### PR TITLE
add JetAnnotations.Name

### DIFF
--- a/jetbrick-template/src/main/java/jetbrick/template/JetAnnotations.java
+++ b/jetbrick-template/src/main/java/jetbrick/template/JetAnnotations.java
@@ -26,6 +26,7 @@ import java.lang.annotation.*;
  * 
  * @since 1.2.0
  * @author Guoqiang Chen
+ * @author Zhuo Ying
  */
 public final class JetAnnotations {
 
@@ -44,4 +45,9 @@ public final class JetAnnotations {
     public static @interface Tags {
     }
 
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public static @interface Name {
+        String value() default "";
+    }
 }

--- a/jetbrick-template/src/main/java/jetbrick/template/resolver/function/FunctionInvokerResolver.java
+++ b/jetbrick-template/src/main/java/jetbrick/template/resolver/function/FunctionInvokerResolver.java
@@ -19,13 +19,20 @@
  */
 package jetbrick.template.resolver.function;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import jetbrick.bean.*;
+import jetbrick.bean.ExecutableUtils;
+import jetbrick.bean.KlassInfo;
+import jetbrick.bean.MethodInfo;
+import jetbrick.template.JetAnnotations;
 import jetbrick.template.resolver.SignatureUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * 用于查找全局注册的扩展函数.
@@ -56,6 +63,10 @@ public final class FunctionInvokerResolver {
      */
     public void register(MethodInfo method) {
         String name = method.getName();
+        JetAnnotations.Name rename = method.getMethod().getAnnotation(JetAnnotations.Name.class);
+        if (rename != null && !"".equals(rename.value())) {
+            name = rename.value();
+        }
 
         if (log.isInfoEnabled()) {
             StringBuffer sb = new StringBuffer();

--- a/jetbrick-template/src/main/java/jetbrick/template/resolver/method/MethodInvokerResolver.java
+++ b/jetbrick-template/src/main/java/jetbrick/template/resolver/method/MethodInvokerResolver.java
@@ -19,13 +19,20 @@
  */
 package jetbrick.template.resolver.method;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import jetbrick.bean.*;
+import jetbrick.bean.ExecutableUtils;
+import jetbrick.bean.KlassInfo;
+import jetbrick.bean.MethodInfo;
+import jetbrick.template.JetAnnotations;
 import jetbrick.template.resolver.SignatureUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * 用于查找全局注册的扩展方法.
@@ -56,6 +63,10 @@ public final class MethodInvokerResolver {
      */
     public void register(MethodInfo method) {
         String name = method.getName();
+        JetAnnotations.Name rename = method.getMethod().getAnnotation(JetAnnotations.Name.class);
+        if (rename != null && !"".equals(rename.value())) {
+            name = rename.value();
+        }
 
         if (log.isInfoEnabled()) {
             Class<?>[] parameterTypes = method.getParameterTypes();

--- a/jetbrick-template/src/main/java/jetbrick/template/resolver/tag/TagInvokerResolver.java
+++ b/jetbrick-template/src/main/java/jetbrick/template/resolver/tag/TagInvokerResolver.java
@@ -19,14 +19,21 @@
  */
 package jetbrick.template.resolver.tag;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import jetbrick.bean.*;
+import jetbrick.bean.ExecutableUtils;
+import jetbrick.bean.KlassInfo;
+import jetbrick.bean.MethodInfo;
+import jetbrick.template.JetAnnotations;
 import jetbrick.template.resolver.SignatureUtils;
 import jetbrick.template.runtime.JetTagContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * 用于查找全局注册的 Tag.
@@ -60,6 +67,10 @@ public final class TagInvokerResolver {
      */
     public void register(MethodInfo method) {
         String name = method.getName();
+        JetAnnotations.Name rename = method.getMethod().getAnnotation(JetAnnotations.Name.class);
+        if (rename != null && !"".equals(rename.value())) {
+            name = rename.value();
+        }
 
         if (log.isInfoEnabled()) {
             StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
强哥，你好。

我在JetAnnotation中添加一个标注

```
public final class JetAnnotations {

    @Target(ElementType.METHOD)
    @Retention(RetentionPolicy.RUNTIME)
    public static @interface Name {
        String value() default "";
    }
}
```

在用户注册func, method或tag 时可以实现重命名

```
package com.github.yingzhuo.cheliangbao.server.jetx2;

import jetbrick.template.JetAnnotations;
import org.apache.commons.lang3.time.DateFormatUtils;
import java.util.Date;

@JetAnnotations.Methods
public class Jetx2Methods {

    @JetAnnotations.Name("to_string")
    public static String toString(Date date, String pattern) {
        return DateFormatUtils.format(date, pattern);
    }
}
```

如上述扩展方法名为驼峰式，而被注册到Jetx的名字为下划线式。

jex 输出日志如下:

```
2016-01-22 11:22:32.353 [main] INFO  jetbrick.template.resolver.GlobalResolver[74] - Scanning @JetMethods, @JetFunctions, @JetTags implements from [com.github.yingzhuo.cheliangbao.server.jetx2] ...
2016-01-22 11:22:32.358 [main] INFO  jetbrick.template.resolver.GlobalResolver[79] - Found 1 annotated classes, time elapsed 5 ms.
2016-01-22 11:22:32.360 [main] DEBUG jetbrick.template.resolver.method.MethodInvokerResolver[84] - import method: Date.to_string(java.lang.String)
2016-01-22 11:22:32.360 [main] INFO  jetbrick.template.resolver.method.MethodInvokerResolver[58] - import 1 methods from class com.github.yingzhuo.cheliangbao.server.jetx2.Jetx2Methods
```