### PR TITLE
Add SpringClasspathResourceLoader for SpringBoot 'All in 1' jar.

### DIFF
--- a/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/JetTemplateAutoConfiguration.java
+++ b/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/JetTemplateAutoConfiguration.java
@@ -1,16 +1,16 @@
 /**
  * Copyright 2013-2016 Guoqiang Chen, Shanghai, China. All rights reserved.
- *
- *   Author: Guoqiang Chen
- *    Email: subchen@gmail.com
- *   WebURL: https://github.com/subchen
- *
+ * <p>
+ * Author: Guoqiang Chen
+ * Email: subchen@gmail.com
+ * WebURL: https://github.com/subchen
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ public class JetTemplateAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(JetTemplateViewResolver.class)
     public JetTemplateViewResolver jetTemplateViewResolver(JetTemplateProperties properties) {
-        mergeConfigs(properties.getConfig());
+        mergeConfigs(properties);
         JetTemplateViewResolver resolver = new JetTemplateViewResolver();
         resolver.setPrefix(properties.getPrefix());
         resolver.setSuffix(properties.getSuffix());
@@ -66,11 +66,15 @@ public class JetTemplateAutoConfiguration {
         return resolver;
     }
 
-    private void mergeConfigs(Properties props) {
+    private void mergeConfigs(JetTemplateProperties properties) {
+        if (properties.getConfig() == null) {
+            properties.setConfig(new Properties());
+        }
+
         for (String key : DEFAULT_CONFIGS.keySet()) {
-            if (props.containsKey(key) == false) {
+            if (properties.getConfig().containsKey(key) == false) {
                 String value = DEFAULT_CONFIGS.get(key);
-                props.put(key, value);
+                properties.getConfig().put(key, value);
             }
         }
     }

--- a/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/SpringClasspathResourceLoader.java
+++ b/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/SpringClasspathResourceLoader.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2013-2016 Guoqiang Chen, Shanghai, China. All rights reserved.
+ *
+ *   Author: Guoqiang Chen
+ *    Email: subchen@gmail.com
+ *   WebURL: https://github.com/subchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrick.template.web.springboot;
+
+import jetbrick.io.resource.AbstractResource;
+import jetbrick.io.resource.Resource;
+import jetbrick.io.resource.ResourceNotFoundException;
+import jetbrick.template.loader.AbstractResourceLoader;
+import jetbrick.util.PathUtils;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class SpringClasspathResourceLoader extends AbstractResourceLoader {
+
+    private final ResourceLoader springResourceLoader;
+
+    public SpringClasspathResourceLoader() {
+        super.root = "";
+        super.reloadable = false;
+        this.springResourceLoader = new DefaultResourceLoader();
+    }
+
+    @Override
+    public final void setReloadable(boolean reloadable) {
+        if (reloadable) {
+            final String message = String.format("%s cannnot be reloadable.", SpringClasspathResourceLoader.class.getName());
+            throw new UnsupportedOperationException(message);
+        }
+        super.reloadable = false;
+    }
+
+    @Override
+    public Resource load(String name) {
+        String path = PathUtils.concat(super.getRoot(), name);
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+
+        org.springframework.core.io.Resource springResource = springResourceLoader.getResource("classpath:" + path);
+        SpringClasspathResource resource = new SpringClasspathResource(springResource);
+        if (!resource.exist()) {
+            return null;
+        } else {
+            resource.setRelativePathName(name);
+            return resource;
+        }
+    }
+
+    private static class SpringClasspathResource extends AbstractResource {
+
+        private final org.springframework.core.io.Resource springResource;
+
+        public SpringClasspathResource(org.springframework.core.io.Resource springResource) {
+            this.springResource = springResource;
+        }
+
+        @Override
+        public InputStream openStream() throws ResourceNotFoundException {
+            try {
+                return springResource.getInputStream();
+            } catch (IOException e) {
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public URL getURL() {
+            try {
+                return springResource.getURL();
+            } catch (IOException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public boolean exist() {
+            return springResource.exists();
+        }
+
+        @Override
+        public boolean isDirectory() {
+            try {
+                return springResource.getFile().isDirectory();
+            } catch (IOException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean isFile() {
+            try {
+                return springResource.getFile().isFile();
+            } catch (IOException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public long length() {
+            if (getURL() == null) {
+                return -1;
+            }
+            try {
+                return getURL().openConnection().getContentLengthLong();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public long lastModified() {
+            // you never think about reloading...
+            // sorry. this code is dirty.
+            return Long.MAX_VALUE;
+        }
+    }
+}

--- a/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/SpringClasspathResourceLoader.java
+++ b/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/SpringClasspathResourceLoader.java
@@ -122,7 +122,7 @@ public class SpringClasspathResourceLoader extends AbstractResourceLoader {
                 return -1;
             }
             try {
-                return getURL().openConnection().getContentLengthLong();
+                return getURL().openConnection().getContentLength();
             } catch (IOException e) {
                 throw new IllegalStateException(e);
             }


### PR DESCRIPTION
强哥好。 本次更新添加了`SpringClasspathResourceLoader` 作为用户使用SpringBoot时的默认的ResourceLoader.

`spring-boot`配置例为

```
spring.jetbrick.template.enabled=true
spring.jetbrick.template.charset=UTF-8
spring.jetbrick.template.cache=true
spring.jetbrick.template.order=-100
spring.jetbrick.template.prefix=templates/
spring.jetbrick.template.suffix=.html
spring.jetbrick.template.config.jetx.input.encoding=UTF-8
spring.jetbrick.template.config.jetx.output.encoding=UTF-8
```

[example codes](https://github.com/yingzhuo/springboot-jetx2-examples)