### PR TITLE
"org.springframework.context.annotation.Configuration" 元注释被误用了 其实没有起到…

### DIFF
--- a/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/JetTemplateAutoConfiguration.java
+++ b/jetbrick-template-springmvc/src/main/java/jetbrick/template/web/springboot/JetTemplateAutoConfiguration.java
@@ -19,8 +19,8 @@
  */
 package jetbrick.template.web.springboot;
 
-import jetbrick.template.JetEngine;
 import jetbrick.template.JetConfig;
+import jetbrick.template.JetEngine;
 import jetbrick.template.loader.ClasspathResourceLoader;
 import jetbrick.template.web.springmvc.JetTemplateViewResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -29,10 +29,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+
 import java.util.Properties;
 
-@Configuration
 @ConditionalOnWebApplication
 @ConditionalOnClass(JetEngine.class)
 @ConditionalOnProperty(value = "spring.jetbrick.template.enabled", havingValue = "true")


### PR DESCRIPTION
"org.springframework.context.annotation.Configuration" 元注释被误用了 其实没有起任何作用 故删除之